### PR TITLE
Always forward the env variables of the simulator docker image

### DIFF
--- a/cosmotech/orchestrator/core/step.py
+++ b/cosmotech/orchestrator/core/step.py
@@ -98,10 +98,11 @@ class Step:
                     break
                 _v = ""
             _env[k] = _v
-        # Special case for "PATH" EnvVar due to subprocess run method
-        # to avoid needing to add "UseSystemEnv" in every step
-        if "PATH" not in _env and os.environ.get("PATH"):
-            _env["PATH"] = os.environ.get("PATH")
+        # Special case for some standard env var (mostly the ones configured in the docker image by default)
+        # This avoids needing to add "useSystemEnvironment" in every/most steps
+        for env_name in ["PATH", "PYTHONPATH", "LD_LIBRARY_PATH", "SSL_CERT_DIR"]:
+            if env_name not in _env and os.environ.get(env_name):
+                _env[env_name] = os.environ.get(env_name)
         return _env
 
     def run(self, dry: bool = False, previous=None):

--- a/partials/orchestrator_known_issues.md
+++ b/partials/orchestrator_known_issues.md
@@ -1,4 +1,2 @@
 !!! warning "Potential Issues"
-    A known issue exists with graphical commands.  
-    Adding the Environment Variable `PATH` and `PYTHONPATH` (or set `useSystemEnvironment` to `true`) to a step 
-    using a Cosmo Tech Simulator is required for the Simulator to run 
+    A known issue exists with graphical commands.


### PR DESCRIPTION
This way executables and python wrapping work as intented by default even through the orchestrator