### PR TITLE
Handle the generated main renaming to csm-simulator

### DIFF
--- a/cosmotech/orchestrator/console_scripts/entrypoint.py
+++ b/cosmotech/orchestrator/console_scripts/entrypoint.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from shutil import which
 from zipfile import ZipFile
 
 from rich.logging import RichHandler
@@ -30,8 +31,6 @@ RESOURCE_PROVIDER_GIT = "git"
 RESOURCE_MAIN = "main.py"
 RESOURCE_ZIP = "resource.zip"
 RESOURCE_REQUIREMENTS = "requirements.txt"
-
-CSM_MAIN = "main"
 
 DEFAULT_PATH_ROOT_LOCAL = "/pkg/share/"
 DEFAULT_RUN_TEMPLATES_ROOT_FOLDER = "code/run_templates/"
@@ -287,7 +286,7 @@ def run_direct_simulator():
 
         if CSM_CONTROL_PLANE_TOPIC is not None:
             logging.debug(f"Control plane topic: {CSM_CONTROL_PLANE_TOPIC}."
-                          "Main Simulator binary is able to handle "
+                          "Simulator binary is able to handle "
                           "CSM_CONTROL_PLANE_TOPIC directly so it is not "
                           "transformed as an argument.")
         else:
@@ -298,9 +297,15 @@ def run_direct_simulator():
             args = sys.argv[1:]
         else:
             args = sys.argv[2:]
-        logging.debug(f"main arguments: {args}")
+        logging.debug(f"Simulator arguments: {args}")
 
-    subprocess.check_call([CSM_MAIN] + args)
+    simulator_exe_name = "csm-simulator"
+    # Check for old simulator name below SDK version 11.1.0
+    old_main = "main"
+    if which(simulator_exe_name) is None and which(old_main):
+        simulator_exe_name = old_main
+
+    subprocess.check_call([simulator_exe_name] + args)
 
 
 def run_engine():
@@ -310,7 +315,7 @@ def run_engine():
         CSM_ENGINE_PATH,
         ENGINE_DEFAULT_PATH_TEMPLATE,
         run_direct_simulator,
-        "direct main simulator"
+        "direct simulator"
     )
 
 

--- a/cosmotech/orchestrator/console_scripts/run_step.py
+++ b/cosmotech/orchestrator/console_scripts/run_step.py
@@ -60,7 +60,9 @@ def executor(project: pathlib.Path, template: str, steps: list[str]):
     template_path = project / "code/run_templates" / target_template
     available_steps = list(template_path.glob('*'))
     csmdocker = False
-    engine_possible_paths = [project / "Generated/Build/Bin/main", pathlib.Path("/pkg/bin/main")]
+    engine_possible_paths = [project / "Generated/Build/Bin/csm-simulator", pathlib.Path("/pkg/bin/csm-simulator")]
+    # Add old names for compatibility with SDK pre v11.1.0
+    engine_possible_paths += [project / "Generated/Build/Bin/main", pathlib.Path("/pkg/bin/main")]
     engine_path = None
     if "CSMDOCKER" in steps:
         steps = ["parameters_handler", "validator", "prerun", "engine", "postrun"]
@@ -94,7 +96,7 @@ def executor(project: pathlib.Path, template: str, steps: list[str]):
     for s in _steps:
         if s == "engine" and engine_path is not None:
             if not (simulation := os.environ.get('CSM_SIMULATION')):
-                LOGGER.error("To use direct main simulation (no engine step in python) "
+                LOGGER.error("To use direct simulator (no engine step in python) "
                              "you need to set the environment variable CSM_SIMULATION "
                              "with the name of the simulation file to be run")
                 return 1
@@ -107,7 +109,7 @@ def executor(project: pathlib.Path, template: str, steps: list[str]):
 
                 if os.environ.get('CSM_CONTROL_PLANE_TOPIC') is not None:
                     LOGGER.debug(f"Control plane topic: {os.environ['CSM_CONTROL_PLANE_TOPIC']}."
-                                 "Main Simulator binary is able to handle "
+                                 "Simulator binary is able to handle "
                                  "CSM_CONTROL_PLANE_TOPIC directly so it is not "
                                  "transformed as an argument.")
                 r = subprocess.run(args=args,


### PR DESCRIPTION
The SDK 11.1.0 renames all executable it provides. Of interest here is the generated 'main' that is now 'csm-simulator'. While the SDK will keep a 'main' fallback for compatibility, this handles the new name by default and fallback to the old one in case the orchestrator is used pre v11.1.0