### PR TITLE
Adding subfolder lookup in the plugin glob search

### DIFF
--- a/cosmotech/orchestrator/__init__.py
+++ b/cosmotech/orchestrator/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.2'
+VERSION = '1.4.3'

--- a/cosmotech/orchestrator/templates/plugin.py
+++ b/cosmotech/orchestrator/templates/plugin.py
@@ -26,7 +26,7 @@ class Plugin:
 
     def load_folder(self, plugin_folder: pathlib.Path):
         count = 0
-        for _path in plugin_folder.glob("templates/*.json"):
+        for _path in plugin_folder.glob("templates/**/*.json"):
             if _path.is_file():
                 with _path.open("r") as _file:
                     try:


### PR DESCRIPTION
this change adds the capability to categorize templates in a plugin using sub folders

This should allow a better way to combine commands by allowing grouping inside plugins

Command ids still need to be defined and made unique though.