### PR TITLE
chore: major version bump to 2.1.0

### DIFF
--- a/cosmotech/orchestrator/__init__.py
+++ b/cosmotech/orchestrator/__init__.py
@@ -5,5 +5,5 @@
 # etc., to any person is prohibited unless it has been previously and
 # specifically authorized by written means by Cosmo Tech.
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 VERSION = __version__


### PR DESCRIPTION
For the release of the entrypoint select.